### PR TITLE
Create the cache and session db

### DIFF
--- a/database/migrations/0001_01_01_000000_create_sessions_table.php
+++ b/database/migrations/0001_01_01_000000_create_sessions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->longText('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sessions');
+    }
+};

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cache', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->mediumText('value');
+            $table->integer('expiration');
+        });
+
+        Schema::create('cache_locks', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->string('owner');
+            $table->integer('expiration');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cache');
+        Schema::dropIfExists('cache_locks');
+    }
+};


### PR DESCRIPTION
**Changes Include:**

- Add:
  
  `0001_01_01_000000_create_sessions_table.php`: Added a migration file to create the sessions table in the database. This table is essential for storing session data when using the database session driver in Laravel.
  `0001_01_01_000001_create_cache_table.php`: Added a migration file to create the cache table in the database. This table is used to store cached data when using the database cache driver in Laravel.

Reason for Changes:

Session Table Migration (0001_01_01_000000_create_sessions_table.php): This migration sets up the sessions table necessary for the database-based session storage. This resolves the issue of missing session data storage when the SESSION_DRIVER is set to database.

Cache Table Migration (0001_01_01_000001_create_cache_table.php): This migration creates the cache table required for the database-based caching mechanism. This resolves errors related to missing cache storage when the CACHE_DRIVER is set to database.