### PR TITLE
Feat/pilner comparepopup

### DIFF
--- a/resources/js/components/ui/ComparePopup.vue
+++ b/resources/js/components/ui/ComparePopup.vue
@@ -33,7 +33,7 @@
                         >
                             <tbody>
                                 <tr
-                                    v-for="(value, key) in initialProduct"
+                                    v-for="(value, key) in filteredInitialProduct"
                                     :key="key"
                                 >
                                     <th class="text-left text-neutral-600 w-[100px]">{{ key }}</th>
@@ -53,7 +53,7 @@
                             class="table-fixed label-1 font-semibold mt-[32px] border-separate border-spacing-[20px]"
                         >
                             <tbody>
-                                <tr v-for="(value, key) in comparedProduct">
+                                <tr v-for="(value, key) in filteredComparedProduct">
                                     <th class="text-left text-neutral-600 w-[100px]">{{ key }}</th>
                                     <td class="text-neutral-400">{{ value }}</td>
                                 </tr>
@@ -72,21 +72,6 @@ export default {
     data() {
         return {
             open: false,
-            initialProduct: {
-                Name: 'iPhone 15 Pro Max',
-                Network: 'GSM / CDMA / HSPA / EVDO / LTE / 5G',
-                Launch: '2023, September 12',
-                Dimension: '159.9 x 76.7 x 8.3 mm (6.30 x 3.02 x 0.33 in)',
-                Weight: '221 g (7.80 oz)',
-                Resolution: '1290 x 2796 pixels, 19.5:9 ratio (~460 ppi density)',
-                Chipset: 'Apple A17 Pro (3 nm)',
-                GPU: 'Apple GPU (6-core graphics)',
-                Features: 'Dual-LED dual-tone flash, HDR (photo/panorama)',
-                Modules: '12 MP, f/1.9, 23mm (wide), 1/3.6", PDAF, OIS',
-                Sensors: 'Face ID, accelerometer, gyro, proximity, compass, barometer',
-                Battery: 'Li-Ion 4441 mAh, non-removable',
-                Colors: 'Black Titanium, White Titanium, Blue Titanium, Natural Titanium',
-            },
             comparedProduct: {},
         };
     },
@@ -103,7 +88,7 @@ export default {
         DropDownCompare,
     },
     props: {
-        initialProducts: {
+        initialProduct: {
             type: Object,
             required: true,
         },
@@ -113,22 +98,22 @@ export default {
         },
     },
     computed: {
-        // filteredInitialProduct() {
-        //     return Object.keys(this.initialProduct)
-        //         .filter((key) => key.toLowerCase() !== 'name')
-        //         .reduce((obj, key) => {
-        //             obj[key] = this.initialProduct[key];
-        //             return obj;
-        //         }, {});
-        // },
-        // filteredComparedProduct() {
-        //     return Object.keys(this.comparedProduct)
-        //         .filter((key) => key.toLowerCase() !== 'name')
-        //         .reduce((obj, key) => {
-        //             obj[key] = this.comparedProduct[key];
-        //             return obj;
-        //         }, {});
-        // },
+        filteredInitialProduct() {
+            return Object.keys(this.initialProduct)
+                .filter((key) => key.toLowerCase() !== 'name')
+                .reduce((obj, key) => {
+                    obj[key] = this.initialProduct[key];
+                    return obj;
+                }, {});
+        },
+        filteredComparedProduct() {
+            return Object.keys(this.comparedProduct)
+                .filter((key) => key.toLowerCase() !== 'name')
+                .reduce((obj, key) => {
+                    obj[key] = this.comparedProduct[key];
+                    return obj;
+                }, {});
+        },
     },
 };
 </script>

--- a/resources/js/components/ui/DropDownCompare.vue
+++ b/resources/js/components/ui/DropDownCompare.vue
@@ -10,7 +10,7 @@
         <transition>
             <div
                 v-if="open"
-                class="absolute top-full translate-x-1/2 right-1/2 text-center min-w-[7.5rem] w-full"
+                class="absolute top-full translate-x-1/2 right-1/2 text-center min-w-full"
                 :class="variantClassesDropDown"
             >
                 <div class="h-[33px] w-full bg-blue-300 flex items-center justify-center">


### PR DESCRIPTION
## How to use
```vue
<template>
    <section class="min-h-screen">
        <div class="container border border-blue-500 h-full">
            <ComparePopup
                :initialProduct="initialProduct"
                :remainingProducts="remainingProducts"
            >
                <p>test</p>
            </ComparePopup>
        </div>
    </section>
</template>
```
```vue
<script>
import ComparePopup from '../components/ui/ComparePopup.vue';
export default {
    name: 'ProfilePage',
    components: {
        ComparePopup,
    },
    data() {
        return {
            initialProduct: {
                Name: 'iPhone 15 Pro Max',
                Network: 'GSM / CDMA / HSPA / EVDO / LTE / 5G',
                Launch: '2023, September 12',
                Dimension: '159.9 x 76.7 x 8.3 mm (6.30 x 3.02 x 0.33 in)',
                Weight: '221 g (7.80 oz)',
                Resolution: '1290 x 2796 pixels, 19.5:9 ratio (~460 ppi density)',
                Chipset: 'Apple A17 Pro (3 nm)',
                GPU: 'Apple GPU (6-core graphics)',
                Features: 'Dual-LED dual-tone flash, HDR (photo/panorama)',
                Modules: '12 MP, f/1.9, 23mm (wide), 1/3.6", PDAF, OIS',
                Sensors: 'Face ID, accelerometer, gyro, proximity, compass, barometer',
                Battery: 'Li-Ion 4441 mAh, non-removable',
                Colors: 'Black Titanium, White Titanium, Blue Titanium, Natural Titanium',
            },
            remainingProducts: [
                {
                    Name: 'iPhone 15 Pro Max 2',
                    Network: 'GSM / CDMA / HSPA / EVDO / LTE / 5G',
                    Launch: '2023, September 12',
                    Dimension: '159.9 x 76.7 x 8.3 mm (6.30 x 3.02 x 0.33 in)',
                    Weight: '221 g (7.80 oz)',
                    Resolution: '1290 x 2796 pixels, 19.5:9 ratio (~460 ppi density)',
                    Chipset: 'Apple A17 Pro (3 nm)',
                    GPU: 'Apple GPU (6-core graphics)',
                    Features: 'Dual-LED dual-tone flash, HDR (photo/panorama)',
                    Modules: '12 MP, f/1.9, 23mm (wide), 1/3.6", PDAF, OIS',
                    Sensors: 'Face ID, accelerometer, gyro, proximity, compass, barometer',
                    Battery: 'Li-Ion 4441 mAh, non-removable',
                    Colors: 'Black Titanium, White Titanium, Blue Titanium, Natural Titanium',
                },
                {
                    Name: 'iPhone 15 Pro Max 3',
                    Network: 'GSM / CDMA / HSPA / EVDO / LTE / 5G',
                    Launch: '2023, September 12',
                    Dimension: '159.9 x 76.7 x 8.3 mm (6.30 x 3.02 x 0.33 in)',
                    Weight: '221 g (7.80 oz)',
                    Resolution: '1290 x 2796 pixels, 19.5:9 ratio (~460 ppi density)',
                    Chipset: 'Apple A17 Pro (3 nm)',
                    GPU: 'Apple GPU (6-core graphics)',
                    Features: 'Dual-LED dual-tone flash, HDR (photo/panorama)',
                    Modules: '12 MP, f/1.9, 23mm (wide), 1/3.6", PDAF, OIS',
                    Sensors: 'Face ID, accelerometer, gyro, proximity, compass, barometer',
                    Battery: 'Li-Ion 4441 mAh, non-removable',
                    Colors: 'Black Titanium, White Titanium, Blue Titanium, Natural Titanium',
                },
                {
                    Name: 'iPhone 15 Pro Max 4',
                    Network: 'GSM / CDMA / HSPA / EVDO / LTE / 5G',
                    Launch: '2023, September 12',
                    Dimension: '159.9 x 76.7 x 8.3 mm (6.30 x 3.02 x 0.33 in)',
                    Weight: '221 g (7.80 oz)',
                    Resolution: '1290 x 2796 pixels, 19.5:9 ratio (~460 ppi density)',
                    Chipset: 'Apple A17 Pro (3 nm)',
                    GPU: 'Apple GPU (6-core graphics)',
                    Features: 'Dual-LED dual-tone flash, HDR (photo/panorama)',
                    Modules: '12 MP, f/1.9, 23mm (wide), 1/3.6", PDAF, OIS',
                    Sensors: 'Face ID, accelerometer, gyro, proximity, compass, barometer',
                    Battery: 'Li-Ion 4441 mAh, non-removable',
                    Colors: 'Black Titanium, White Titanium, Blue Titanium, Natural Titanium',
                },
            ],
        };
    },
};
</script>

```


#### Changes includes
- **Add:**
    - `<FILENAME>`: <REASON>

- **Modify:**
    - `<FILENAME>`: <REASON>

- **Remove:**
    - `<FILENAME>`: <REASON>


#### Packages installed (if there's any):
- `<PACKAGE NAME>`: <REASON>


#### Questions/Issues (if there's any):


#### Tasks to do (if it's still a work in progress upon PR):
